### PR TITLE
Recreate some directories needed by apt

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -141,6 +141,8 @@ run cp -R -v $CACHE_DIR/.root $BUILD_DIR/
 # Free up some space in the slug.
 echo "-----> Freeing some space."
 rm -rf $BUILD_DIR/.root/var/cache/apt $BUILD_DIR/.root/usr/share/doc $BUILD_DIR/.root/var/lib/apt/lists
+# and re-create some directories needed by apt
+mkdir -p $BUILD_DIR/.root/var/cache/apt/archives/partial $BUILD_DIR/.root/var/lib/apt/lists/partial
 
 cd $BUILD_DIR/.root
 rm app


### PR DESCRIPTION
Re-create some directories needed by apt-get.

This allows `apt-get update; apt-get install ...` to run with no fanfare.
